### PR TITLE
Fixed logo when viewed in dark-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   
-[![LogoMakr-9E4Yff](https://user-images.githubusercontent.com/73739820/121773936-e018f200-cb9c-11eb-9200-be3ad4eef565.png)](https://github.com/CodeFlow201/GitMarkonics)
+[![LogoMakr-9E4Yff](https://raw.githubusercontent.com/supzi-del/test-repo/main/GitMarkonics%20(1).jpg)](https://github.com/CodeFlow201/GitMarkonics)
 
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat&logo=github)](https://github.com/CodeFlow201/GitMarkonics) 
 [![Open Source Love](https://img.shields.io/badge/Open%20Source-%F0%9F%A4%8D-Green)](https://github.com/CodeFlow201/GitMarkonics) 


### PR DESCRIPTION
Fixes #49 
Added a jpg image of the logo with a white bg so that it is visible in both light and dark mode. And I used the original logo which is on the website if that's okay.
![Screenshot (229)](https://user-images.githubusercontent.com/78655439/122766912-b1e39280-d2bf-11eb-9465-36d9089cbda3.png)
